### PR TITLE
add_allowed_hosts_winmac - Quick PR fixing the allowed hosts to the project

### DIFF
--- a/sellotape/sellotape_dj/sellotape_dj/settings.py
+++ b/sellotape/sellotape_dj/sellotape_dj/settings.py
@@ -26,8 +26,10 @@ SECRET_KEY = 'gtk7i_g+v%afq6dvplwms_-*r3j7uj-k6g4b&&iu#ys-e(ui)0'
 DEBUG = True
 
 ALLOWED_HOSTS = [
-    '0.0.0.0',
-    '127.0.0.1'
+	'127.0.0.1', 
+	'[::1]',
+	'0.0.0.0',
+	'localhost'
 ]
 
 


### PR DESCRIPTION
The commit is a quick fix to a problem regarded to #15 and #21,
The default (debug=true) Django ALLOWED_HOSTS has been added the host '0.0.0.0' for compatibility for both Windows and Mac users.

https://docs.djangoproject.com/en/2.2/ref/settings/#allowed-hosts