### PR TITLE
User Page (backend)

### DIFF
--- a/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
+++ b/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
@@ -9,7 +9,7 @@
 {% block content %}
     <div class="header">
         <a href="/{{profile.username}}">
-            <h2>{{ profile.first_name }} {{ profile.last_name }}</h2>
+            <h2>{{ profile.user.first_name }} {{ profile.user.last_name }}</h2>
         </a>
         {% if live_stream %}
             <span class="red-dot"></span>
@@ -18,7 +18,7 @@
 
     {% if live_stream %}
         <div class="section">
-            {{ profile.first_name}} is live now at
+            {{ profile.user.first_name}} is live now at
             <a class="live-link" href="{{ live_stream.link }}">{{ live_stream.link }}</a>.
         </div>
     {% endif %}

--- a/sellotape/sellotape_dj/main_app/tests.py
+++ b/sellotape/sellotape_dj/main_app/tests.py
@@ -1,5 +1,9 @@
 from django.test import TestCase
 from django.utils import timezone
+from django.urls import reverse
+
+from .models import Stream
+from django.contrib.auth.models import User
 
 from django.template.loader import render_to_string
 
@@ -78,3 +82,95 @@ class UserTemplateTests(TestCase):
         self.assertTrue('<h4>Stream 1</h4>' in html)
         self.assertTrue('<h4>Stream 2</h4>' in html)
         self.assertTrue('Airs on Jan. 1, 2018' in html)
+
+class UserViewTests(TestCase):
+    def test_user_does_not_exist(self):
+        """
+        If user does not exist, it returns a 404.
+        """
+        url = reverse('main_app:user', args=('non-exist',))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_no_streams(self):
+        """
+        If no streams are available, an appropriate message is displayed.
+        """
+        username = 'darth-vader'
+        create_user(username)
+
+        url = reverse('main_app:user', args=(username,))
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        # self.assertContains(response, "No streams are available.")
+        self.assertQuerysetEqual(response.context['future_streams'], [])
+        self.assertQuerysetEqual(response.context['previous_streams'], [])
+        self.assertTemplateUsed(response, 'sellotape/user.html')
+
+    def test_finds_live_stream(self):
+        """
+        If there is a live stream happening at the moment,
+        it should be passed to the response context.
+        """
+        username = 'darth-vader'
+        user = create_user(username)
+        
+        now = timezone.now()
+        streams = [
+            {
+                'author': user,
+                'airs_on': now.replace(hour=(now.hour - 1)),
+                'ends_on': now.replace(hour=(now.hour + 1)),
+                'title': 'Live Stream',
+                'added_on': now
+            },
+        ]
+        create_streams(streams)
+
+        url = reverse('main_app:user', args=(username,))
+        response = self.client.get(url)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['live_stream'])
+        self.assertEqual(response.context['live_stream'].title, 'Live Stream')
+
+    def test_splits_streams(self):
+        """
+        The view should split future and previous streams based on the current time
+        and the streams data.
+        """
+        username = 'darth-vader'
+        user = create_user(username)
+
+        now = timezone.now()
+        streams = [
+            {
+                'author': user,
+                'airs_on': now.replace(year=(now.year + 1)),
+                'ends_on': None,
+                'title': 'Future Stream',
+                'added_on': now
+            },
+            {
+                'author': user,
+                'airs_on': now.replace(year=(now.year - 1)),
+                'ends_on': now.replace(hour=now.hour),
+                'title': 'Previous Stream',
+                'added_on': now
+              }
+
+        ]
+        create_streams(streams)
+
+        url = reverse('main_app:user', args=(username,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        future_streams = response.context['future_streams']
+        previous_streams = response.context['previous_streams']
+        
+        self.assertTrue(len(future_streams))
+        self.assertTrue(len(previous_streams))
+        self.assertEqual(future_streams[0].title, 'Future Stream')
+        self.assertEqual(previous_streams[0].title, 'Previous Stream')

--- a/sellotape/sellotape_dj/main_app/tests.py
+++ b/sellotape/sellotape_dj/main_app/tests.py
@@ -2,19 +2,22 @@ from django.test import TestCase
 from django.utils import timezone
 from django.urls import reverse
 
-from .models import Stream
+from .models import Stream, Profile
 from django.contrib.auth.models import User
 
 from django.template.loader import render_to_string
 
 
+
 class UserTemplateTests(TestCase):
     def test_shows_profile_name(self):
         """It should display the first and last name of the user."""
-        user = {
-            'username': 'darth-vader',
-            'first_name': 'Darth',
-            'last_name': 'Vader'
+        profile = {
+            'user': {
+                'username': 'darth-vader',
+                'first_name': 'Darth',
+                'last_name': 'Vader'
+            }
         }
 
         html = render_to_string('sellotape/user.html', {'profile': user})
@@ -41,7 +44,9 @@ class UserTemplateTests(TestCase):
         }
 
         context = {
-            'profile': user,
+            'profile': {
+                'user': user,
+            },
             'live_stream': live_stream
         }
 
@@ -94,16 +99,15 @@ class UserViewTests(TestCase):
 
     def test_no_streams(self):
         """
-        If no streams are available, an appropriate message is displayed.
+        If no streams are available, it should response with the right context.
         """
         username = 'darth-vader'
-        create_user(username)
+        create_profile(username)
 
         url = reverse('main_app:user', args=(username,))
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
-        # self.assertContains(response, "No streams are available.")
         self.assertQuerysetEqual(response.context['future_streams'], [])
         self.assertQuerysetEqual(response.context['previous_streams'], [])
         self.assertTemplateUsed(response, 'sellotape/user.html')
@@ -114,7 +118,7 @@ class UserViewTests(TestCase):
         it should be passed to the response context.
         """
         username = 'darth-vader'
-        user = create_user(username)
+        user = create_profile(username)
         
         now = timezone.now()
         streams = [
@@ -141,7 +145,7 @@ class UserViewTests(TestCase):
         and the streams data.
         """
         username = 'darth-vader'
-        user = create_user(username)
+        user = create_profile(username)
 
         now = timezone.now()
         streams = [

--- a/sellotape/sellotape_dj/main_app/tests/test_templates.py
+++ b/sellotape/sellotape_dj/main_app/tests/test_templates.py
@@ -1,9 +1,6 @@
 from django.test import TestCase
 from django.utils import timezone
 
-from ..models import Stream, Profile
-from django.contrib.auth.models import User
-
 from django.template.loader import render_to_string
 
 
@@ -18,14 +15,14 @@ class UserTemplateTests(TestCase):
             }
         }
 
-        html = render_to_string('sellotape/user.html', { 'profile': profile })
+        html = render_to_string('sellotape/user.html', {'profile': profile})
         self.assertTrue('<h2>Darth Vader</h2>' in html)
 
     def test_shows_no_streams_message(self):
         """It should display an appropriate message when no streams are available."""
-        user = { 'username': 'darth-vader' }
-        profile = { 'user': user }
-        html = render_to_string('sellotape/user.html', { 'profile': profile })
+        user = {'username': 'darth-vader'}
+        profile = {'user': user}
+        html = render_to_string('sellotape/user.html', {'profile': profile})
         self.assertTrue('<h3>No streams are available.</h3>' in html)
 
     def test_shows_live_stream(self):
@@ -58,11 +55,11 @@ class UserTemplateTests(TestCase):
         date = timezone.datetime(2025, 1, 1)
 
         future_streams = [
-            { 'title': 'Stream 1', 'airs_on': date },
-            { 'title': 'Stream 2', 'airs_on': date }
+            {'title': 'Stream 1', 'airs_on': date},
+            {'title': 'Stream 2', 'airs_on': date}
         ]
 
-        context = { 'future_streams': future_streams }
+        context = {'future_streams': future_streams}
         html = render_to_string('sellotape/user.html', context)
 
         self.assertTrue('<h3>Future Streams</h3>' in html)
@@ -75,11 +72,11 @@ class UserTemplateTests(TestCase):
         date = timezone.datetime(2018, 1, 1)
 
         future_streams = [
-            { 'title': 'Stream 1', 'airs_on': date },
-            { 'title': 'Stream 2', 'airs_on': date }
+            {'title': 'Stream 1', 'airs_on': date},
+            {'title': 'Stream 2', 'airs_on': date}
         ]
 
-        context = { 'future_streams': future_streams }
+        context = {'future_streams': future_streams}
         html = render_to_string('sellotape/user.html', context)
 
         self.assertTrue('<h3>Future Streams</h3>' in html)

--- a/sellotape/sellotape_dj/main_app/tests/test_templates.py
+++ b/sellotape/sellotape_dj/main_app/tests/test_templates.py
@@ -1,0 +1,88 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from ..models import Stream, Profile
+from django.contrib.auth.models import User
+
+from django.template.loader import render_to_string
+
+
+class UserTemplateTests(TestCase):
+    def test_shows_profile_name(self):
+        """It should display the first and last name of the user."""
+        profile = {
+            'user': {
+                'username': 'darth-vader',
+                'first_name': 'Darth',
+                'last_name': 'Vader'
+            }
+        }
+
+        html = render_to_string('sellotape/user.html', { 'profile': profile })
+        self.assertTrue('<h2>Darth Vader</h2>' in html)
+
+    def test_shows_no_streams_message(self):
+        """It should display an appropriate message when no streams are available."""
+        user = { 'username': 'darth-vader' }
+        profile = { 'user': user }
+        html = render_to_string('sellotape/user.html', { 'profile': profile })
+        self.assertTrue('<h3>No streams are available.</h3>' in html)
+
+    def test_shows_live_stream(self):
+        """It should display the live link to a stream happening at the moment."""
+        user = {
+            'username': 'darth-vader',
+            'first_name': 'Darth',
+            'last_name': 'Vader'
+        }
+
+        live_stream = {
+            'author': user,
+            'title': 'Live Stream',
+            'link': 'linktomystream.com'
+        }
+
+        context = {
+            'profile': {
+                'user': user,
+            },
+            'live_stream': live_stream
+        }
+
+        html = render_to_string('sellotape/user.html', context)
+        self.assertTrue('Darth is live now at' in html)
+        self.assertTrue('linktomystream.com</a>' in html)
+
+    def test_shows_future_streams(self):
+        """It should display future and previous streams."""
+        date = timezone.datetime(2025, 1, 1)
+
+        future_streams = [
+            { 'title': 'Stream 1', 'airs_on': date },
+            { 'title': 'Stream 2', 'airs_on': date }
+        ]
+
+        context = { 'future_streams': future_streams }
+        html = render_to_string('sellotape/user.html', context)
+
+        self.assertTrue('<h3>Future Streams</h3>' in html)
+        self.assertTrue('<h4>Stream 1</h4>' in html)
+        self.assertTrue('<h4>Stream 2</h4>' in html)
+        self.assertTrue('Airs on Jan. 1, 2025' in html)
+
+    def test_shows_previous_streams(self):
+        """It should display future and previous streams."""
+        date = timezone.datetime(2018, 1, 1)
+
+        future_streams = [
+            { 'title': 'Stream 1', 'airs_on': date },
+            { 'title': 'Stream 2', 'airs_on': date }
+        ]
+
+        context = { 'future_streams': future_streams }
+        html = render_to_string('sellotape/user.html', context)
+
+        self.assertTrue('<h3>Future Streams</h3>' in html)
+        self.assertTrue('<h4>Stream 1</h4>' in html)
+        self.assertTrue('<h4>Stream 2</h4>' in html)
+        self.assertTrue('Airs on Jan. 1, 2018' in html)

--- a/sellotape/sellotape_dj/main_app/tests/test_views.py
+++ b/sellotape/sellotape_dj/main_app/tests/test_views.py
@@ -13,12 +13,14 @@ def create_profile(username):
     user = User.objects.create(username=username)
     return Profile.objects.create(user=user)
 
+
 def create_streams(streams):
     """
     Create streams for the test db.
     """
     for stream in streams:
         Stream.objects.create(**stream)
+
 
 class UserViewTests(TestCase):
     def test_user_does_not_exist(self):
@@ -51,7 +53,7 @@ class UserViewTests(TestCase):
         """
         username = 'darth-vader'
         user = create_profile(username)
-        
+
         now = timezone.now()
         streams = [
             {
@@ -66,7 +68,7 @@ class UserViewTests(TestCase):
 
         url = reverse('main_app:user', args=(username,))
         response = self.client.get(url)
-        
+
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['live_stream'])
         self.assertEqual(response.context['live_stream'].title, 'Live Stream')
@@ -105,7 +107,7 @@ class UserViewTests(TestCase):
 
         future_streams = response.context['future_streams']
         previous_streams = response.context['previous_streams']
-        
+
         self.assertTrue(len(future_streams))
         self.assertTrue(len(previous_streams))
         self.assertEqual(future_streams[0].title, 'Future Stream')

--- a/sellotape/sellotape_dj/main_app/tests/test_views.py
+++ b/sellotape/sellotape_dj/main_app/tests/test_views.py
@@ -2,91 +2,23 @@ from django.test import TestCase
 from django.utils import timezone
 from django.urls import reverse
 
-from .models import Stream, Profile
+from ..models import Stream, Profile
 from django.contrib.auth.models import User
 
-from django.template.loader import render_to_string
 
+def create_profile(username):
+    """
+    Create a user for the test db by a given username.
+    """
+    user = User.objects.create(username=username)
+    return Profile.objects.create(user=user)
 
-
-class UserTemplateTests(TestCase):
-    def test_shows_profile_name(self):
-        """It should display the first and last name of the user."""
-        profile = {
-            'user': {
-                'username': 'darth-vader',
-                'first_name': 'Darth',
-                'last_name': 'Vader'
-            }
-        }
-
-        html = render_to_string('sellotape/user.html', {'profile': user})
-        self.assertTrue('<h2>Darth Vader</h2>' in html)
-
-    def test_shows_no_streams_message(self):
-        """It should display an appropriate message when no streams are available."""
-        user = {'username': 'darth-vader'}
-        html = render_to_string('sellotape/user.html', {'profile': user})
-        self.assertTrue('<h3>No streams are available.</h3>' in html)
-
-    def test_shows_live_stream(self):
-        """It should display the live link to a stream happening at the moment."""
-        user = {
-            'username': 'darth-vader',
-            'first_name': 'Darth',
-            'last_name': 'Vader'
-        }
-
-        live_stream = {
-            'author': user,
-            'title': 'Live Stream',
-            'link': 'linktomystream.com'
-        }
-
-        context = {
-            'profile': {
-                'user': user,
-            },
-            'live_stream': live_stream
-        }
-
-        html = render_to_string('sellotape/user.html', context)
-        self.assertTrue('Darth is live now at' in html)
-        self.assertTrue('linktomystream.com</a>' in html)
-
-    def test_shows_future_streams(self):
-        """It should display future and previous streams."""
-        date = timezone.datetime(2025, 1, 1)
-
-        future_streams = [
-            {'title': 'Stream 1', 'airs_on': date},
-            {'title': 'Stream 2', 'airs_on': date}
-        ]
-
-        context = {'future_streams': future_streams}
-        html = render_to_string('sellotape/user.html', context)
-
-        self.assertTrue('<h3>Future Streams</h3>' in html)
-        self.assertTrue('<h4>Stream 1</h4>' in html)
-        self.assertTrue('<h4>Stream 2</h4>' in html)
-        self.assertTrue('Airs on Jan. 1, 2025' in html)
-
-    def test_shows_previous_streams(self):
-        """It should display future and previous streams."""
-        date = timezone.datetime(2018, 1, 1)
-
-        future_streams = [
-            {'title': 'Stream 1', 'airs_on': date},
-            {'title': 'Stream 2', 'airs_on': date}
-        ]
-
-        context = {'future_streams': future_streams}
-        html = render_to_string('sellotape/user.html', context)
-
-        self.assertTrue('<h3>Future Streams</h3>' in html)
-        self.assertTrue('<h4>Stream 1</h4>' in html)
-        self.assertTrue('<h4>Stream 2</h4>' in html)
-        self.assertTrue('Airs on Jan. 1, 2018' in html)
+def create_streams(streams):
+    """
+    Create streams for the test db.
+    """
+    for stream in streams:
+        Stream.objects.create(**stream)
 
 class UserViewTests(TestCase):
     def test_user_does_not_exist(self):

--- a/sellotape/sellotape_dj/main_app/urls.py
+++ b/sellotape/sellotape_dj/main_app/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.index, name='index')
+    path('', views.index, name='index'),
+    path('<str:username>/', views.user, name='user'),
 ]

--- a/sellotape/sellotape_dj/main_app/views.py
+++ b/sellotape/sellotape_dj/main_app/views.py
@@ -1,7 +1,7 @@
 from django.utils import timezone
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.models import User
-from .models import Stream
+from .models import Stream, Profile
 
 
 def index(request):
@@ -9,8 +9,9 @@ def index(request):
 
 def user(request, username):
     # Get the profile for the passed username or raise 404 if not found.
-    user = get_object_or_404(User, username=username)
-    streams = Stream.objects.filter(author=user)
+    # If found, retrieve the related profile streams.
+    profile = get_object_or_404(Profile, user__username=username)
+    streams = Stream.objects.filter(author=profile)
 
     # Check if there is a live stream at the moment.
     live_stream = None
@@ -29,7 +30,7 @@ def user(request, username):
         previous_streams.remove(live_stream)
 
     context = {
-        'profile': user,
+        'profile': profile,
         'future_streams': future_streams,
         'previous_streams': previous_streams,
         'live_stream': live_stream,

--- a/sellotape/sellotape_dj/main_app/views.py
+++ b/sellotape/sellotape_dj/main_app/views.py
@@ -1,11 +1,11 @@
 from django.utils import timezone
 from django.shortcuts import render, get_object_or_404
-from django.contrib.auth.models import User
 from .models import Stream, Profile
 
 
 def index(request):
     return render(request, 'sellotape/index.html')
+
 
 def user(request, username):
     # Get the profile for the passed username or raise 404 if not found.
@@ -17,7 +17,7 @@ def user(request, username):
     live_stream = None
     now = timezone.now()
     for s in streams:
-        ongoing = s.ends_on == None or s.ends_on >= now
+        ongoing = s.ends_on is None or s.ends_on >= now
         if ongoing and s.airs_on <= now:
             live_stream = s
             break

--- a/sellotape/sellotape_dj/main_app/views.py
+++ b/sellotape/sellotape_dj/main_app/views.py
@@ -1,5 +1,37 @@
-from django.shortcuts import render
+from django.utils import timezone
+from django.shortcuts import render, get_object_or_404
+from django.contrib.auth.models import User
+from .models import Stream
 
 
 def index(request):
     return render(request, 'sellotape/index.html')
+
+def user(request, username):
+    # Get the profile for the passed username or raise 404 if not found.
+    user = get_object_or_404(User, username=username)
+    streams = Stream.objects.filter(author=user)
+
+    # Check if there is a live stream at the moment.
+    live_stream = None
+    now = timezone.now()
+    for s in streams:
+        ongoing = s.ends_on == None or s.ends_on >= now
+        if ongoing and s.airs_on <= now:
+            live_stream = s
+            break
+
+    # Filter streams data based on the current time of serving the page.
+    future_streams = [s for s in streams if s.airs_on > now]
+    previous_streams = [s for s in streams if s not in future_streams]
+
+    if live_stream in previous_streams:
+        previous_streams.remove(live_stream)
+
+    context = {
+        'profile': user,
+        'future_streams': future_streams,
+        'previous_streams': previous_streams,
+        'live_stream': live_stream,
+    }
+    return render(request, 'sellotape/user.html', context)

--- a/sellotape/sellotape_dj/sellotape_dj/urls.py
+++ b/sellotape/sellotape_dj/sellotape_dj/urls.py
@@ -18,5 +18,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include(('main_app.urls', 'main_app'), namespace='main_app'))
+    path('', include(('main_app.urls', 'main_app'), namespace='main_app')),
 ]


### PR DESCRIPTION
Handles the backend logic for #7.

In this PR:
- Made some modifications to the `Stream` Model, and therefore the new migration files.
- Implemented a `user` view that handles GET requests to `/<username>/`:
    - Results in a 404 if the user does not exist.
    - Otherwise, fetches the streams related to that user's Profile.
    - If there is a live stream occurring at the moment, find it.
    - Separate past and future streams to pass on to the template (`previous_streams` and `future_streams`).
- Implemented the relevant tests for the view.

Note that this PR is the first part of a 2-part task for #7, and that the frontend part is completed ([PR is opened](#39)).

Thanks




