### PR TITLE
User Page (frontend)

### DIFF
--- a/sellotape/sellotape_dj/main_app/static/sellotape/user.css
+++ b/sellotape/sellotape_dj/main_app/static/sellotape/user.css
@@ -1,0 +1,50 @@
+.header {
+    display: flex;
+    align-items: center;
+}
+
+.header a {
+    color: black
+}
+
+h2 {
+    margin-right: 20px;
+    text-decoration: underline;
+}
+
+.red-dot {
+    height: 12px;
+    width: 12px;
+    background-color: red;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.live-link {
+    color: #2d2d2d;
+    text-decoration: none;
+}
+
+.section {
+    margin-bottom: 50px;
+}
+
+.streams {
+    margin: 0;
+    padding: 0;
+}
+
+.streams li {
+    display: flex;
+    flex-direction: column;
+    padding: 10px 20px;
+    transition: box-shadow .2s ease-in-out;
+    position: relative;
+    width: 100%;
+    flex-shrink: 0;
+    border-radius: 8px;
+    border: 1px solid #e8f2ff;
+    background-color: #e8f2ff;
+    box-shadow: 0 2px 6px 1px #e1e5e8;
+    margin-bottom: 14px;
+}

--- a/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
+++ b/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
@@ -8,7 +8,7 @@
 
 {% block content %}
     <div class="header">
-        <a href="{% url 'user' username=profile.username %}">
+        <a href="{% url 'main_app:user' username=profile.username %}">
             <h2>{{ profile.first_name }} {{ profile.last_name }}</h2>
         </a>
         {% if live_stream %}
@@ -23,32 +23,42 @@
         </div>
     {% endif %}
 
-    <div class="section">
-        <h3>Future Streams</h3>
-        <ul class="streams">
-            {% for stream in future_streams %}
-                <li>
-                    <h4>{{ stream.title }}</h4>
-                    <p>
-                        Airs on {{ stream.airs_on|date }} <a href="{{ stream.link }}">here</a>.
-                    </p>
-                </li>
-            {% endfor %}
-        </ul>
-    </div>
+    {% if future_streams|length %}
+        <div class="section">
+            <h3>Future Streams</h3>
+            <ul class="streams">
+                {% for stream in future_streams %}
+                    <li>
+                        <h4>{{ stream.title }}</h4>
+                        <p>
+                            Airs on {{ stream.airs_on|date }} <a href="{{ stream.link }}">here</a>.
+                        </p>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
 
-    <div class="section">
-        <h3>Previous Streams</h3>
-        <ul class="streams">
-            {% for stream in previous_streams %}
-                <li>
-                    <h4>{{ stream.title }}</h4>
-                    <p>
-                        Aired on {{ stream.airs_on|date }} <a href="{{ stream.link }}">here</a>. <br/>
-                        The stream ended on {{ stream.ended_on|date }}.
-                    </p>
-                </li>
-            {% endfor %}
-        </ul>
-    </div>
+    {% if previous_streams|length %}
+        <div class="section">
+            <h3>Previous Streams</h3>
+            <ul class="streams">
+                {% for stream in previous_streams %}
+                    <li>
+                        <h4>{{ stream.title }}</h4>
+                        <p>
+                            Aired on {{ stream.airs_on|date }} <a href="{{ stream.link }}">here</a>. <br/>
+                            The stream ended on {{ stream.ended_on|date }}.
+                        </p>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if not future_streams|length and not previous_streams|length %}
+        <div class="section">
+            <h3>No streams are available.</h3>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
+++ b/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
@@ -8,7 +8,7 @@
 
 {% block content %}
     <div class="header">
-        <a href="{% url 'main_app:user' username=profile.username %}">
+        <a href="/{{profile.username}}">
             <h2>{{ profile.first_name }} {{ profile.last_name }}</h2>
         </a>
         {% if live_stream %}

--- a/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
+++ b/sellotape/sellotape_dj/main_app/templates/sellotape/user.html
@@ -1,0 +1,54 @@
+{% extends 'sellotape/base.html' %}
+
+{% load static %}
+
+{% block customlinks %}
+<link rel="stylesheet" type="text/css" href="{% static 'sellotape/user.css' %}">
+{% endblock %}
+
+{% block content %}
+    <div class="header">
+        <a href="{% url 'user' username=profile.username %}">
+            <h2>{{ profile.first_name }} {{ profile.last_name }}</h2>
+        </a>
+        {% if live_stream %}
+            <span class="red-dot"></span>
+        {% endif %}
+    </div>
+
+    {% if live_stream %}
+        <div class="section">
+            {{ profile.first_name}} is live now at
+            <a class="live-link" href="{{ live_stream.link }}">{{ live_stream.link }}</a>.
+        </div>
+    {% endif %}
+
+    <div class="section">
+        <h3>Future Streams</h3>
+        <ul class="streams">
+            {% for stream in future_streams %}
+                <li>
+                    <h4>{{ stream.title }}</h4>
+                    <p>
+                        Airs on {{ stream.airs_on|date }} <a href="{{ stream.link }}">here</a>.
+                    </p>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+
+    <div class="section">
+        <h3>Previous Streams</h3>
+        <ul class="streams">
+            {% for stream in previous_streams %}
+                <li>
+                    <h4>{{ stream.title }}</h4>
+                    <p>
+                        Aired on {{ stream.airs_on|date }} <a href="{{ stream.link }}">here</a>. <br/>
+                        The stream ended on {{ stream.ended_on|date }}.
+                    </p>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endblock %}

--- a/sellotape/sellotape_dj/main_app/tests.py
+++ b/sellotape/sellotape_dj/main_app/tests.py
@@ -1,3 +1,79 @@
 from django.test import TestCase
+from django.utils import timezone
 
-# Create your tests here.
+from django.template.loader import render_to_string
+
+class UserTemplateTests(TestCase):
+    def test_shows_profile_name(self):
+        """It should display the first and last name of the user."""
+        user = {
+            'username': 'darth-vader',
+            'first_name': 'Darth',
+            'last_name': 'Vader'
+        }
+
+        html = render_to_string('sellotape/user.html', { 'profile': user })
+        self.assertTrue('<h2>Darth Vader</h2>' in html)
+
+    def test_shows_no_streams_message(self):
+        """It should display an appropriate message when no streams are available."""
+        user = { 'username': 'darth-vader' }
+        html = render_to_string('sellotape/user.html', { 'profile': user })
+        self.assertTrue('<h3>No streams are available.</h3>' in html)
+
+    def test_shows_live_stream(self):
+        """It should display the live link to a stream happening at the moment."""
+        user = {
+            'username': 'darth-vader',
+            'first_name': 'Darth',
+            'last_name': 'Vader'
+        }
+
+        live_stream = {
+            'author': user,
+            'title': 'Live Stream',
+            'link': 'linktomystream.com'
+        }
+
+        context = {
+            'profile': user,
+            'live_stream': live_stream
+        }
+
+        html = render_to_string('sellotape/user.html', context)
+        self.assertTrue('Darth is live now at' in html)
+        self.assertTrue('linktomystream.com</a>' in html)
+
+    def test_shows_future_streams(self):
+        """It should display future and previous streams."""
+        date = timezone.datetime(2025, 1, 1)
+
+        future_streams = [
+            { 'title': 'Stream 1', 'airs_on': date },
+            { 'title': 'Stream 2', 'airs_on': date }
+        ]
+
+        context = { 'future_streams': future_streams }
+        html = render_to_string('sellotape/user.html', context)
+
+        self.assertTrue('<h3>Future Streams</h3>' in html)
+        self.assertTrue('<h4>Stream 1</h4>' in html)
+        self.assertTrue('<h4>Stream 2</h4>' in html)
+        self.assertTrue('Airs on Jan. 1, 2025' in html)
+
+    def test_shows_previous_streams(self):
+        """It should display future and previous streams."""
+        date = timezone.datetime(2018, 1, 1)
+
+        future_streams = [
+            { 'title': 'Stream 1', 'airs_on': date },
+            { 'title': 'Stream 2', 'airs_on': date }
+        ]
+
+        context = { 'future_streams': future_streams }
+        html = render_to_string('sellotape/user.html', context)
+
+        self.assertTrue('<h3>Future Streams</h3>' in html)
+        self.assertTrue('<h4>Stream 1</h4>' in html)
+        self.assertTrue('<h4>Stream 2</h4>' in html)
+        self.assertTrue('Airs on Jan. 1, 2018' in html)

--- a/sellotape/sellotape_dj/sellotape_dj/urls.py
+++ b/sellotape/sellotape_dj/sellotape_dj/urls.py
@@ -18,5 +18,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include('main_app.urls')),
+    path('', include(('main_app.urls', 'main_app'), namespace='main_app'))
 ]


### PR DESCRIPTION
This PR is the continuation of #38 and it resolves #7.

It introduces the `user.html` template and it's css to display a simple user page. Some more nicer layout might be added in the future (with #35), but currently, it displays the user name, past and future streams. 

If the user is having a live stream at the moment (of the requested time of the page), it will display a red-dot next to his name and show the relevant live link.

For more implementation details on the view that serves this template, see #38.

Thanks.
