### PR TITLE
Added backend for the user-logged-in landing page 

### DIFF
--- a/sellotape/sellotape_dj/main_app/views.py
+++ b/sellotape/sellotape_dj/main_app/views.py
@@ -29,7 +29,7 @@ def landing_logged_on(request):
     }
     return render(request, 'landing_logged_in.html', context)
 
-  
+
 def landing(request):
     if request.user.is_authenticated:
         return landing_logged_on(request)

--- a/sellotape/sellotape_dj/sellotape_dj/settings.py
+++ b/sellotape/sellotape_dj/sellotape_dj/settings.py
@@ -118,5 +118,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
+MEDIA_ROOT = 'media/'
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'

--- a/sellotape/sellotape_dj/sellotape_dj/urls.py
+++ b/sellotape/sellotape_dj/sellotape_dj/urls.py
@@ -16,10 +16,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('', include(('main_app.urls', 'main_app'), namespace='main_app'), name='main_app'),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This is the backend part of the new user-logged-in landing page
- Updated Views: Created a new view to feed a different .html incase of Logged In
- Created the view logic: Gather user's own live & future streams, and also live & future streams of user he follows -> Feed to Front end
- Updated MEDIA_ROOT in settings.py for Avatar's to be fed correctly & saved nicely (not in root like before)