### PR TITLE
Added support for FB & Google

### DIFF
--- a/sellotape/Pipfile
+++ b/sellotape/Pipfile
@@ -10,6 +10,7 @@ django = "*"
 pillow = "*"
 channels = "*"
 twisted = "*"
+social-auth-app-django = "*"
 
 [requires]
 python_version = "3.8"

--- a/sellotape/Pipfile.lock
+++ b/sellotape/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "199adf8e7e420fe08b7fe3101efd9d627cecc2cde5e4ba27fb292bf4aebe8483"
+            "sha256": "4b7620a6afffdf59e1b62544bb0ac8c42963dbff0b1a49ab390109134a17cbd6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,6 +46,13 @@
                 "sha256:b6feb6455337df834f6c9962d6ccf771515b7d939bca142b29c20c2376bc6111"
             ],
             "version": "==20.2.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+            ],
+            "version": "==2020.6.20"
         },
         "cffi": {
             "hashes": [
@@ -96,6 +103,13 @@
             "index": "pypi",
             "version": "==2.4.0"
         },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
         "constantly": {
             "hashes": [
                 "sha256:586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35",
@@ -138,6 +152,14 @@
             ],
             "version": "==2.5.0"
         },
+        "defusedxml": {
+            "hashes": [
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==0.6.0"
+        },
         "django": {
             "hashes": [
                 "sha256:a2127ad0150ec6966655bedf15dbbff9697cc86d61653db2da1afa506c0b04cc",
@@ -167,6 +189,14 @@
                 "sha256:7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3"
             ],
             "version": "==17.5.0"
+        },
+        "oauthlib": {
+            "hashes": [
+                "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
+                "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==3.1.0"
         },
         "pillow": {
             "hashes": [
@@ -255,6 +285,13 @@
             "markers": "python_version >= '3.5'",
             "version": "==2.0.2"
         },
+        "pyjwt": {
+            "hashes": [
+                "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
+                "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
+            ],
+            "version": "==1.7.1"
+        },
         "pyopenssl": {
             "hashes": [
                 "sha256:621880965a720b8ece2f1b2f54ea2071966ab00e2970ad2ce11d596102063504",
@@ -262,12 +299,36 @@
             ],
             "version": "==19.1.0"
         },
+        "python3-openid": {
+            "hashes": [
+                "sha256:33fbf6928f401e0b790151ed2b5290b02545e8775f982485205a066f874aaeaf",
+                "sha256:6626f771e0417486701e0b4daff762e7212e820ca5b29fcc0d05f6f8736dfa6b"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==3.2.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
                 "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
             "version": "==2020.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.24.0"
+        },
+        "requests-oauthlib": {
+            "hashes": [
+                "sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d",
+                "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a",
+                "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"
+            ],
+            "version": "==1.3.0"
         },
         "service-identity": {
             "hashes": [
@@ -283,6 +344,23 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
+        },
+        "social-auth-app-django": {
+            "hashes": [
+                "sha256:2c69e57df0b30c9c1823519c5f1992cbe4f3f98fdc7d95c840e091a752708840",
+                "sha256:567ad0e028311541d7dfed51d3bf2c60440a6fd236d5d4d06c5a618b3d6c57c5",
+                "sha256:df5212370bd250108987c4748419a1a1d0cec750878856c2644c36aaa0fd3e58"
+            ],
+            "index": "pypi",
+            "version": "==4.0.0"
+        },
+        "social-auth-core": {
+            "hashes": [
+                "sha256:21c0639c56befd33ec162c2210d583bb1de8e1136d53b21bafb96afaf2f86c91",
+                "sha256:2f6ce1af8ec2b2cc37b86d647f7d4e4292f091ee556941db34b1e0e2dee77fc0",
+                "sha256:4a3cdf69c449b235cdabd54a1be7ba3722611297e69fded52e3584b1a990af25"
+            ],
+            "version": "==3.3.3"
         },
         "sqlparse": {
             "hashes": [
@@ -331,6 +409,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==20.4.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.25.10"
         },
         "zope.interface": {
             "hashes": [

--- a/sellotape/sellotape_dj/main_app/templates/login.html
+++ b/sellotape/sellotape_dj/main_app/templates/login.html
@@ -19,7 +19,7 @@
                 Hey there! please choose your preferred authentication method and join us here at Sellotape!
                 <div class="row justify-content-md-center">
                     <div class="col-3">
-                        <a href="" style="font-size: 1rem;color:#dc3545">
+                        <a href="{% url 'social:begin' 'google-oauth2' %}" style="font-size: 1rem;color:#dc3545">
                           <span style="font-size: 5rem;color:#dc3545">
                             <i class="fab fa-google-plus"></i>
                           </span><br />
@@ -27,7 +27,7 @@
                         </a>
                     </div>
                     <div class="col-3">
-                        <a href="" style="font-size: 1rem;color:#3b5998">
+                        <a href="{% url 'social:begin' 'facebook' %}" style="font-size: 1rem;color:#3b5998">
                           <span style="font-size: 5rem;color:#3b5998">
                             <i class="fab fa-facebook"></i>
                           </span><br />

--- a/sellotape/sellotape_dj/main_app/urls.py
+++ b/sellotape/sellotape_dj/main_app/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('complete-login/', views.complete_login, name='complete-login'),
     path('', views.landing, name='landing'),
     path('<str:username>/', views.user, name='user'),
     path('follow/<str:username>/', views.follow, name='follow'),

--- a/sellotape/sellotape_dj/main_app/views.py
+++ b/sellotape/sellotape_dj/main_app/views.py
@@ -3,7 +3,6 @@ import tempfile
 import os.path
 
 from django.core import files
-from django.http import HttpResponseNotFound, HttpResponseBadRequest
 from django.utils import timezone
 from django.shortcuts import render, get_object_or_404, redirect
 from .models import Stream, Profile, UserFollower

--- a/sellotape/sellotape_dj/main_app/views.py
+++ b/sellotape/sellotape_dj/main_app/views.py
@@ -1,6 +1,13 @@
+import requests
+import tempfile
+import os.path
+
+from django.core import files
+from django.http import HttpResponseNotFound, HttpResponseBadRequest
 from django.utils import timezone
 from django.shortcuts import render, get_object_or_404, redirect
 from .models import Stream, Profile, UserFollower
+from social_django.models import UserSocialAuth
 
 
 def landing_logged_on(request):
@@ -109,3 +116,60 @@ def follow(request, username):
     user_follow = UserFollower(user=follower_profile, follows=to_follow_profile)
     user_follow.save()
     return redirect('main_app:user', username=username)
+
+
+def complete_login(request):
+    if request.user.is_anonymous:
+        return redirect('/')
+
+    profile = Profile.objects.filter(user=request.user)
+    if len(profile) > 0:
+        return redirect('/')
+
+    social_auths = UserSocialAuth.objects.filter(user=request.user)
+    if len(social_auths) <= 0:
+        return redirect('/')
+
+    picture = social_auths[0].extra_data["picture"]
+
+    # Facebook pictures are further wrapped in the following way
+    if type(picture) is dict:
+        picture = picture["data"]["url"]
+
+    # Steam the image from the url
+    pic_req = requests.get(picture, stream=True)
+
+    # Was the request OK?
+    if pic_req.status_code != requests.codes.ok:
+        # Nope, error handling, skip file etc etc etc
+        picture = None
+    else:
+        # Create a temporary file
+        lf = tempfile.NamedTemporaryFile()
+
+        # Get the filename from the url, used for saving later
+        file_name = os.path.basename(lf.name)
+
+        # Read the streamed image in sections
+        for block in pic_req.iter_content(1024 * 8):
+
+            # If no more file then stop
+            if not block:
+                break
+
+            # Write image block to temporary file
+            lf.write(block)
+
+    city = Profile.City.tel_aviv
+
+    new_profile = Profile()
+    new_profile.user = request.user
+    new_profile.city = city
+    if picture is not None:
+        # Save the temporary image to the model#
+        # This saves the model so be sure that is it valid
+        new_profile.avatar.save(file_name, files.File(lf))
+    new_profile.youtube_link = ''
+    new_profile.twitch_link = ''
+    new_profile.save()
+    return redirect('/')

--- a/sellotape/sellotape_dj/sellotape_dj/settings.py
+++ b/sellotape/sellotape_dj/sellotape_dj/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 from pathlib import Path
+from json import load
 import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -41,10 +42,17 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'social_django',
     'main_app.apps.MainAppConfig',
     'chat',
     'channels',
 ]
+
+AUTHENTICATION_BACKENDS = (
+    'social_core.backends.google.GoogleOAuth2',
+    'social_core.backends.facebook.FacebookOAuth2',
+    'django.contrib.auth.backends.ModelBackend',
+)
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -69,6 +77,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },
@@ -133,5 +143,46 @@ MEDIA_ROOT = 'media/'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static')
 ]
-LOGIN_REDIRECT_URL = '/'
+LOGIN_URL = '/login/'
+LOGOUT_URL = '/logout/'
+LOGIN_REDIRECT_URL = '/complete-login/'
 LOGOUT_REDIRECT_URL = '/'
+
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.social_auth.associate_by_email',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
+)
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = '~'
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = '~'
+SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = ['email']
+SOCIAL_AUTH_GOOGLE_OAUTH2_PROFILE_EXTRA_PARAMS = {
+    'fields': 'id, name, email, picture.type(large)'
+}
+SOCIAL_AUTH_GOOGLE_OAUTH2_EXTRA_DATA = [
+    ('name', 'name'),
+    ('email', 'email'),
+    ('picture', 'picture')
+]
+
+SOCIAL_AUTH_FACEBOOK_KEY = "~"  # App ID
+SOCIAL_AUTH_FACEBOOK_SECRET = "~"  # App Secret
+SOCIAL_AUTH_FACEBOOK_SCOPE = SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = SOCIAL_AUTH_GOOGLE_OAUTH2_PROFILE_EXTRA_PARAMS
+SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = SOCIAL_AUTH_GOOGLE_OAUTH2_EXTRA_DATA
+
+SELLOTAPE_SETTINGS_PATH = Path(BASE_DIR).joinpath("settings.json")
+if SELLOTAPE_SETTINGS_PATH.exists():
+    with open(SELLOTAPE_SETTINGS_PATH) as fp:
+        settings = load(fp)
+        SOCIAL_AUTH_FACEBOOK_KEY = settings["facebook"]["key"]
+        SOCIAL_AUTH_FACEBOOK_SECRET = settings["facebook"]["secret"]
+        SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = settings["google"]["key"]
+        SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = settings["google"]["secret"]

--- a/sellotape/sellotape_dj/sellotape_dj/urls.py
+++ b/sellotape/sellotape_dj/sellotape_dj/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    path('', include('social_django.urls', namespace="social")),
     path('chat/', include('chat.urls', namespace='chat')),
     path('', include(('main_app.urls', 'main_app'), namespace='main_app'), name='main_app'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/sellotape/sellotape_dj/settings.json
+++ b/sellotape/sellotape_dj/settings.json
@@ -1,0 +1,10 @@
+{
+	"facebook": {
+		"key": "",
+		"secret": ""
+	},
+	"google": {
+		"key": "",
+		"secret": ""
+	}
+}


### PR DESCRIPTION
This PR enables the authentication via Facebook & Google.
It adds a settings.json, which is empty by default but is shared among us and should be filled when required to use these authentication methods.
If left to default, the app will still work fine, just if you try to login via the social methods it will throw a "bad app id" error